### PR TITLE
Resolve #257 and #258 by using ~/.inputrc if it is found (and only change HOME if it is not found)

### DIFF
--- a/clink/dll/dll.c
+++ b/clink/dll/dll.c
@@ -31,7 +31,6 @@ void                    save_history();
 void                    shutdown_lua();
 void                    shutdown_clink_settings();
 int                     get_clink_setting_int(const char*);
-void                    prepare_env_for_inputrc();
 
 inject_args_t           g_inject_args;
 static const shell_t*   g_shell                 = NULL;
@@ -109,9 +108,7 @@ static BOOL on_dll_attach()
         disable_log();
     }
 
-    // Prepare the process and environment for Readline.
     set_rl_readline_name();
-    prepare_env_for_inputrc();
 
     // Search for a supported shell.
     {

--- a/clink/dll/inputrc
+++ b/clink/dll/inputrc
@@ -67,4 +67,3 @@ set keymap emacs
 # "\t": clink-menu-completion-shim
 # "\e`Z": clink-backward-menu-completion-shim
 
-$include ~/clink_inputrc

--- a/clink/dll/rl.c
+++ b/clink/dll/rl.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2012 Martin Ridgers
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -46,6 +46,7 @@ void                add_to_history(const char*);
 int                 expand_from_history(const char*, char**);
 int                 history_expand_control(char*, int);
 void                initialise_fwrite();
+void                prepare_env_for_inputrc();
 
 int                 g_slash_translation             = 0;
 extern int          rl_visible_stats;
@@ -302,7 +303,7 @@ char** match_display_filter(char** matches, int match_count)
         int is_dir = 0;
         int len;
         char* base = NULL;
-        
+
         // If matches are files then strip off the path and establish if they
         // are directories.
         if (rl_filename_completion_desired)
@@ -476,7 +477,13 @@ static int initialise_hook()
     clink_register_rl_funcs();
     initialise_rl_scroller();
 
-    rl_re_read_init_file(0, 0);
+    if(rl_re_read_init_file(0, 0))
+    {
+        // Failed to read an inputrc file, so set things up to use the clink
+        // default
+        prepare_env_for_inputrc();
+        rl_re_read_init_file(0, 0);
+    }
     rl_visible_stats = 0;               // serves no purpose under win32.
 
     rl_startup_hook = NULL;

--- a/docs/api.md
+++ b/docs/api.md
@@ -165,7 +165,7 @@ Returns true if **path** resolves to a directory.
 
 ##### clink.is_rl_variable_true(readline_var_name)
 
-Returns the boolean value of a Readline variable. These can be set with the clink_inputrc file, more details of which can be found in the [Readline manual](http://tinyurl.com/oum26rp).
+Returns the boolean value of a Readline variable. These can be set with the inputrc file, more details of which can be found in the [Readline manual](http://tinyurl.com/oum26rp).
 
 ##### clink.lower(text)
 

--- a/docs/clink.md
+++ b/docs/clink.md
@@ -60,7 +60,12 @@ Configuring Clink by and large involves configuring Readline by creating a [Read
 - a file named `.inputrc` in the directory specified by the HOME environment variable
 - a file named `/etc/inputrc`, i.e. the inputrc file in the etc folder at the root of the current drive letter when clink is started
 
-If Readline is unable to find an inputrc file, then Clink will configure Readline using some default settings, and also look for a file named `clink_inputrc` in the Clink profile directory described above.  You can put any additional Readline configuration into `clink_inputrc`.
+Clink's default Readline configuration can be found in the `inputrc` file located in the same directory as Clink's core files.  You can include Clink's default inputrc into your own inputrc file in order to use it as a starting point (recommended):
+```
+$include <path/to/clink/dir>/inputrc
+```
+
+If Readline is unable to find an inputrc file, then Clink will configure Readline using the inputrc found in Clink's installation directory, and also look for a file named `clink_inputrc` in the Clink profile directory described above.  You can put any additional Readline configuration into `clink_inputrc`.
 
 #### Clink-Specific Settings
 

--- a/docs/clink.md
+++ b/docs/clink.md
@@ -41,9 +41,9 @@ When running Clink via the methods above, Clink checks the parent process is sup
 
 The easiest way to configure Clink is to use Clink's **set** command line option.  This can list, query, and set Clink's settings. Run **clink set --help** from a Clink-installed cmd.exe process to learn more both about how to use it and to get descriptions for Clink's various options.
 
-Configuring Clink by and large involves configuring Readline by creating a **clink_inputrc** file. There is excellent documentation for all the options available to configure Readline in Readline's [manual](http://tinyurl.com/oum26rp).
+#### Clink Profile Directory
 
-Where Clink looks for **clink_inputrc** (as well as .lua scripts and the settings file) depends on which distribution of Clink was used. If you installed Clink using the .exe installer then Clink uses the current user's non-roaming application data directory. This user directory is usually found in one of the following locations;
+Clink looks for various scripts and configuration files in the Clink **profile** directory.  The location of this directory depends on which distribution of Clink was used. If you installed Clink using the .exe installer then Clink uses the current user's non-roaming application data directory. This user directory is usually found in one of the following locations:
 
 - c:\Documents and Settings\\&lt;username&gt;\Local Settings\Application Data *(XP)*
 - c:\Users\\&lt;username&gt;\AppData\Local *(Vista onwards)*
@@ -52,7 +52,17 @@ The .zip distribution of Clink creates and uses a directory called **profile** w
 
 All of the above locations can be overriden using the **--profile &lt;path&gt;** command line option which is specified when injecting Clink into cmd.exe using **clink inject**.
 
-#### Settings
+#### Readline Configuration
+
+Configuring Clink by and large involves configuring Readline by creating a [Readline Init File](http://tinyurl.com/otd9bv5), also known as an **inputrc** file. There is excellent documentation for all the options available to configure Readline in the [Readline manual](http://tinyurl.com/oum26rp). Readline will look for the inputrc file in several places and use the first one it finds:
+
+- a file specified by the INPUTRC environment variable
+- a file named `.inputrc` in the directory specified by the HOME environment variable
+- a file named `/etc/inputrc`, i.e. the inputrc file in the etc folder at the root of the current drive letter when clink is started
+
+If Readline is unable to find an inputrc file, then Clink will configure Readline using some default settings, and also look for a file named `clink_inputrc` in the Clink profile directory described above.  You can put any additional Readline configuration into `clink_inputrc`.
+
+#### Clink-Specific Settings
 
 It is also possible to configure settings specific to Clink. These are stored in a file called **settings** which is found in one of the locations mentioned in the previous section. The settings file gets created the first time Clink is run.
 
@@ -83,7 +93,7 @@ The Readline library allows clients to offer an alternative path for creating co
 
 #### The Location of Lua Scripts
 
-Clink looks for Lua scripts in the folders as described in the **Configuring Clink** section. By default **Ctrl-Q** is mapped to reload all Lua scripts which can be useful when developing and iterating on your own scripts.
+Clink looks for Lua scripts in the Clink **profile** directory described above. By default **Ctrl-Q** is mapped to reload all Lua scripts which can be useful when developing and iterating on your own scripts.
 
 #### Match Generators
 
@@ -287,7 +297,7 @@ Insert   | R      | i     | W     | )
 Delete   | S      | j     | X     | \*
 Tab      | (n/a)  | Z     | (n/a) | (n/a)
 
-Here is an example line from a clink_inputrc file that binds Shift-End to the Readline function **transpose-word** function;
+Here is an example line from an inputrc file that binds Shift-End to the Readline function **transpose-word** function;
 
 ```
 "\e`f": transpose-word

--- a/installer/clink.nsi
+++ b/installer/clink.nsi
@@ -115,6 +115,7 @@ Section "!Application files" app_files_id
     File ${CLINK_BUILD}\LICENSE
     File ${CLINK_BUILD}\clink_x*.exe
     File ${CLINK_BUILD}\clink.bat
+    File ${CLINK_BUILD}\inputrc
     File ${CLINK_BUILD}\clink_inputrc_base
     File ${CLINK_BUILD}\clink.html
 

--- a/installer/premake4.lua
+++ b/installer/premake4.lua
@@ -195,7 +195,7 @@ newaction {
             "clink_x*.exe",
             "clink*.dll",
             "*.lua",
-            "clink_inputrc_base",
+            "inputrc",
             "CHANGES",
             "LICENSE",
             "clink_dll_x*.pdb",
@@ -205,6 +205,12 @@ newaction {
         for _, mask in ipairs(manifest) do
             copy(src .. mask, dest)
         end
+
+        -- Copy the default inputrc and add the include line to the end
+        exec("copy "..dest.."\\inputrc "..dest.."\\clink_inputrc_base")
+        local new_inputrc = io.open(dest.."\\clink_inputrc_base", "a")
+        new_inputrc:write("$include ~/clink_inputrc\n")
+        new_inputrc:close()
 
         -- Lump lua files together.
         unlink(dest .. "/clink._lua")

--- a/premake4.lua
+++ b/premake4.lua
@@ -186,11 +186,11 @@ project("clink_dll")
     files("clink/version.rc")
 
     configuration("release")
-        build_postbuild("clink/dll/clink_inputrc_base", "release")
+        build_postbuild("clink/dll/inputrc", "release")
         build_postbuild("clink/lua/*.lua", "release")
 
     configuration("debug")
-        build_postbuild("clink/dll/clink_inputrc_base", "debug")
+        build_postbuild("clink/dll/inputrc", "debug")
         build_postbuild("clink/lua/*.lua", "debug")
 
     configuration("vs*")

--- a/readline/compat/hooks.c
+++ b/readline/compat/hooks.c
@@ -21,6 +21,7 @@
 
 #include <Windows.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <wchar.h>
 #include <sys/stat.h>
@@ -141,7 +142,7 @@ int hooked_stat(const char* path, struct hooked_stat* out)
     }
     else
     {
-        // Set errno...
+        errno = ENOENT;
     }
 
     return ret;


### PR DESCRIPTION
I've been using this in my own build of Clink for several weeks and have been pretty happy with it.  I have HOME=%USERPROFILE% so I can keep all of my dotfiles there, and now Clink works with that.