### PR TITLE
Make it buildable with VS2010 on WinXP. C98 compliant now.

### DIFF
--- a/clink/dll/shell_cmd.c
+++ b/clink/dll/shell_cmd.c
@@ -109,7 +109,7 @@ static int check_auto_answer()
 {
     static wchar_t* prompt_to_answer = (wchar_t*)1;
     static wchar_t* no_yes;
-
+	wchar_t* c;
     int setting;
     wchar_t* prompt;
 
@@ -134,7 +134,7 @@ static int check_auto_answer()
             no_yes = no_yes ? no_yes : L"ny";
 
             // Strip off new line chars.
-            wchar_t* c = prompt_to_answer;
+            c = prompt_to_answer;
             while (*c)
             {
                 if (*c == '\r' || *c == '\n')


### PR DESCRIPTION
This change is related to https://github.com/mridgers/clink/issues/278
I'm working on an old WinXP machine and I try to fix that issue by recompiling clink locally. I use VS2010 Express and premake premake4 (Premake Build Script Generator) 4.4-beta5
Then fork clone.
cd clink 
premake4.exe vs2010
cd .build\vs2010
msbuild clink.sln

IT originally fail due to variable declaration not at function beginning. It is fixed now, buildable and tested on WinXP (from ConEmu)

