### PR TITLE
determine the running cmd.exe version on a 64-bit platform

### DIFF
--- a/clink/loader/clink.bat
+++ b/clink/loader/clink.bat
@@ -49,7 +49,11 @@ if "%1"=="" (
 if /i "%PROCESSOR_ARCHITECTURE%"=="x86" (
     call :loader_x86 %*
 ) else if /i "%PROCESSOR_ARCHITECTURE%"=="amd64" (
-    call :loader_x64 %*
+    if /i "%ProgramFiles%"=="%ProgramFiles(x86)%" (
+		call :loader_x86 %*
+	) else (
+		call :loader_x64 %*
+	)
 )
 
 :end


### PR DESCRIPTION
You may have a 32-bit cmd.exe on a 64-bit system, so checking the architecture leads to the wrong decision...

See closed issue "inoperable in Telnet Client" #299
https://github.com/mridgers/clink/issues/299