### PR TITLE
Fallback to clink_[x86|x64].exe if clink.bat Script is Renamed

### DIFF
--- a/clink/loader/clink.bat
+++ b/clink/loader/clink.bat
@@ -64,15 +64,24 @@ goto :eof
 :loader_x86
 if exist "%~dpn0_x86.exe" (
     "%~dpn0_x86.exe" %*
-)
+) else if exist "%~dp0clink_x86.exe" (
+    "%~dp0clink_x86.exe" %*
+) 
 exit /b 0
 
 :loader_x64
 if exist "%~dpn0_x64.exe" (
     "%~dpn0_x64.exe" %*
+) else if exist "%~dp0clink_x64.exe" (
+    "%~dp0clink_x64.exe" %*
 )
 exit /b 0
 
 :launch
-start "" cmd.exe /s /k ""%~dpnx0" inject %clink_profile_arg% && title Clink"
+if exist "%~dpn0*.exe" (
+    start "" cmd.exe /s /k ""%~dpnx0" inject %clink_profile_arg% && title Clink"
+)
+else (
+    start "" cmd.exe /s /k "%~dp0clink inject %clink_profile_arg% && title Clink"
+)
 exit /b 0


### PR DESCRIPTION
In programs like ConEmu, very often users want to pass their own options into Clink. This involves replacing clink.bat with their own custom one, which will then call the original clink.bat with a new name. This tweak keeps the original behavior of looking for clinkXXX_x64.exe when the batch script is named clinkXXX.bat, but provides a fallback for it to run clink_x64.exe if clinkXXX_x64.exe cannot be found.