### PR TITLE
fix build on newer premake5

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -114,6 +114,7 @@ solution("clink")
     platforms({"x32", "x64"})
     location(to)
 
+    characterset("MBCS")
     flags("Symbols")
     flags("StaticRuntime")
     defines("HAVE_CONFIG_H")


### PR DESCRIPTION
premake5 alpha8 changed default characterset() to unicode. Set this explicitly to the value clink expects.
