### PR TITLE
Make compatible with Windows 10 > 15002

### DIFF
--- a/clink/shared/hook.c
+++ b/clink/shared/hook.c
@@ -282,6 +282,7 @@ static int get_instruction_length(void* addr)
         { 0x00005340, 0x0000ffff },  // push rbx
         { 0x00dc8b4c, 0x00ffffff },  // mov r11, rsp
         { 0x0000b848, 0x0000f8ff },  // mov reg64, imm64  = 10-byte length
+        { 0x24048B48, 0xffffffff },  // mov rax,QWORD PTR [rsp]
 #elif defined _M_IX86
         { 0x0000ff8b, 0x0000ffff },  // mov edi,edi  
 #endif


### PR DESCRIPTION
This is a fix for issue #431. It seems like in more recent builds of windows, a function that clink patches starts with a different instruction. I just added that instruction to the ones clink recognizes. My assembly is rusty, but it seems "mov rax,QWORD PTR [rsp]" just loads a value into rax in preparation of a function call, and it can be safely moved to the trampoline. 

It works for me, but somebody who understands this stuff better should double check this :-).