### PR TITLE
fix premake config for 5.0alpha11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Clink can be extended through its Lua API which allows easy creation context sen
 
 ### Building Clink
 
-Clink's uses [Premake](http://premake.github.io) to generate Visual Studio solutions or makefiles for MinGW. Note that Premake >= 5.0-alpha8 is required.
+Clink's uses [Premake](http://premake.github.io) to generate Visual Studio solutions or makefiles for MinGW. Note that Premake >= 5.0-alpha11 is required.
 
 1. Cd to your clone of Clink.
 2. Run "premake &lt;toolchain&gt;" (where "&lt;toolchain&gt;" is one of Premake's actions - see "premake --help")

--- a/premake5.lua
+++ b/premake5.lua
@@ -115,7 +115,7 @@ solution("clink")
     location(to)
 
     characterset("MBCS")
-    flags("Symbols")
+    symbols "on"
     flags("StaticRuntime")
     defines("HAVE_CONFIG_H")
     defines("HANDLE_MULTIBYTE")


### PR DESCRIPTION
* for premake 5.0alpha11, 'flags("Symbols")' became deprecated, replaced by the new symbols() API