### PR TITLE
Fix broken doskey alias functionality with Windows 10 (15002)'s modern cmd

### DIFF
--- a/clink/dll/doskey.c
+++ b/clink/dll/doskey.c
@@ -185,8 +185,8 @@ int begin_doskey(wchar_t* chars, unsigned max_chars)
         exe = wcsrchr(exe_path, L'\\');
         exe = (exe != NULL) ? (exe + 1) : exe_path;
 
-        // Check it exists.
-        if (!GetConsoleAliasW(alias, exe_path, 1, exe))
+        // Check it exists. (ERROR_NOT_FOUND is set when an alias is, well, not found)
+        if (!GetConsoleAliasW(alias, exe_path, sizeof(wchar_t), exe) && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
             return 0;
 
         // It does. Allocate space and fetch it.


### PR DESCRIPTION
For #438. As `GetConsoleAlias(W)` works on the byte count, and not the character count, using 1 for the buffer size will fail some `len < sizeof(WCHAR)` test I imagine (read: think) the more stringent Conhost V2 has somewhere instead of succeeding like it does with V1. 