### PR TITLE
fix premake strange error and fix doskey not work under win10 new con…

### DIFF
--- a/clink/dll/doskey.c
+++ b/clink/dll/doskey.c
@@ -73,7 +73,7 @@ int continue_doskey(wchar_t* chars, unsigned max_chars)
 {
     wchar_t* read = g_state.alias_next;
 
-    if (g_state.alias_text == NULL)
+    if (g_state.alias_text == NULL || read == NULL)
         return 0;
 
     if (*read == '\0')

--- a/premake5.lua
+++ b/premake5.lua
@@ -47,13 +47,13 @@ function useXpToolset(base, cfg)
     local p = "v110_xp"
     if _ACTION > "vs2012" then
         p = "v120_xp"
-    end 
+    end
 
     if _ACTION > "vs2010" then
         _p(2,'<PlatformToolset>%s</PlatformToolset>', p)
     end
 end
-premake.override(premake.vstudio.vc2010, 'platformToolset', useXpToolset)
+--premake.override(premake.vstudio.vc2010, 'platformToolset', useXpToolset)
 
 --------------------------------------------------------------------------------
 -- Work around a bug in Premake5


### PR DESCRIPTION
this change fix the problem, clink doskey can only work under legacy console mode. make bash and clink doskey works together under windows 10