### PR TITLE
Speed up clink injection by not suspending threads

### DIFF
--- a/clink/process/include/process/process.h
+++ b/clink/process/include/process/process.h
@@ -20,12 +20,9 @@ public:
     int                         get_parent_pid() const;
     void*                       inject_module(const char* dll);
     template <typename T> void* remote_call(void* function, T const& param);
-    void                        pause();
-    void                        unpause();
 
 private:
     void*                       remote_call(void* function, const void* param, int param_size);
-    void                        pause(bool suspend);
     int                         m_pid;
 
     struct handle
@@ -49,16 +46,4 @@ template <typename T>
 void* process::remote_call(void* function, T const& param)
 {
     return remote_call(function, &param, sizeof(param));
-}
-
-//------------------------------------------------------------------------------
-inline void process::pause()
-{
-    pause(true);
-}
-
-//------------------------------------------------------------------------------
-inline void process::unpause()
-{
-    pause(false);
 }

--- a/clink/terminal/src/win_screen_buffer.cpp
+++ b/clink/terminal/src/win_screen_buffer.cpp
@@ -162,7 +162,7 @@ void win_screen_buffer::set_cursor(int column, int row)
     column = clamp(column, 0, width);
     row = clamp(row, 0, height);
 
-    COORD xy = { window.Left + column, window.Top + row };
+    COORD xy = { static_cast<short>(window.Left + column), static_cast<short>(window.Top + row) };
     SetConsoleCursorPosition(m_handle, xy);
 }
 
@@ -173,8 +173,8 @@ void win_screen_buffer::move_cursor(int dx, int dy)
     GetConsoleScreenBufferInfo(m_handle, &csbi);
 
     COORD xy = {
-        clamp(csbi.dwCursorPosition.X + dx, 0, csbi.dwSize.X - 1),
-        clamp(csbi.dwCursorPosition.Y + dy, 0, csbi.dwSize.Y - 1),
+        static_cast<short>(clamp(csbi.dwCursorPosition.X + dx, 0, csbi.dwSize.X - 1)),
+        static_cast<short>(clamp(csbi.dwCursorPosition.Y + dy, 0, csbi.dwSize.Y - 1)),
     };
     SetConsoleCursorPosition(m_handle, xy);
 }


### PR DESCRIPTION
Iterating over every thread on the system takes a lot of time, and is unnecessary as `cmd.exe` is already blocked (waiting in `WaitForSingleObject()`) whenever clink is being injected. So just don't do it.

Also add a few `static_cast`'s to silence warnings in VS2017 about narrowing conversions.