### PR TITLE
Enable VT processing on stdout

### DIFF
--- a/clink/dll/rl.c
+++ b/clink/dll/rl.c
@@ -507,7 +507,8 @@ static char* call_readline_impl(const char* prompt)
 
     // Make sure that EOL wrap is on. Readline's told the terminal supports it.
     {
-        int stdout_flags = ENABLE_PROCESSED_OUTPUT|ENABLE_WRAP_AT_EOL_OUTPUT;
+        int stdout_flags = ENABLE_PROCESSED_OUTPUT|ENABLE_WRAP_AT_EOL_OUTPUT|
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING;
         HANDLE handle_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
         SetConsoleMode(handle_stdout, stdout_flags);
     }

--- a/clink/dll/rl.c
+++ b/clink/dll/rl.c
@@ -507,10 +507,11 @@ static char* call_readline_impl(const char* prompt)
 
     // Make sure that EOL wrap is on. Readline's told the terminal supports it.
     {
-        int stdout_flags = ENABLE_PROCESSED_OUTPUT|ENABLE_WRAP_AT_EOL_OUTPUT|
-            ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        int stdout_flags = ENABLE_PROCESSED_OUTPUT|ENABLE_WRAP_AT_EOL_OUTPUT;
+        int oldstdout_flags = 0;
         HANDLE handle_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
-        SetConsoleMode(handle_stdout, stdout_flags);
+        GetConsoleMode(handle_stdout, &oldstdout_flags);
+        SetConsoleMode(handle_stdout, stdout_flags|oldstdout_flags);
     }
 
     // Initialisation


### PR DESCRIPTION
Not sure if there is a minimum Windows version, but this is needed
on newer versions of Windows 10 (1903+) with the new Windows Terminal
application. https://github.com/microsoft/terminal

Without this fix the prompt is wrapped based on the number of characters - ***including*** the ANSI escape sequences.  Also, if the line is wrapped in the middle of an escape sequence the output can be corrupt.

This fixes the 0.4.9 release.  I haven't been able to get any of the v1.0 alphas working with my lua scripts.